### PR TITLE
Add initial image build example module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cloudless-image-build-state.json
+id_rsa_image_build
+id_rsa_image_build.pub

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# Base Image Build Example
+
+This is an example of building a base image across multiple cloud providers.
+
+## Usage
+
+Because we are starting from stock Ubuntu images, and because the images
+provided by the different cloud providers have different names, we have to have
+different build configurations.  If you were building on an image that you had
+created, or if you copied the stock configuration to the same name on both
+providers, you could have one configuration for both.
+
+Assuming you've configured the `aws` profile to use the `aws` provider, with the
+`cldls` command, run:
+
+```
+cldls --profile aws image-build run aws_image_build_configuration.yml 
+```
+
+Assuming you've configured the `gce` profile to use the `gce` provider, with the
+`cldls` command, run:
+
+```
+cldls --profile gce image-build run gce_image_build_configuration.yml 
+```
+
+## Workflow
+
+The main value of this framework is that it is focused on the workflow of
+actually developing an image.  For example, if you want to deploy an instance
+that you can work on without running the full build, you can run:
+
+```
+cldls --profile gce image-build deploy gce_image_build_configuration.yml 
+```
+
+This command saves the SSH keys locally and will display the SSH command that
+you need to run to log into the instance.
+
+Now, say you want to actually test that the configuration step works properly:
+
+```
+cldls --profile gce image-build configure gce_image_build_configuration.yml 
+```
+
+You can run this as many times as you want until it's working.  Finally, you can
+run your tests to check that the configuration behaves as expected:
+
+```
+cldls --profile gce image-build check gce_image_build_configuration.yml 
+```
+
+You're done!  Clean everything up with:
+
+```
+cldls --profile gce image-build cleanup gce_image_build_configuration.yml 
+```
+
+You're done!  When you're ready to actually save an image, you can run the full
+build.  Cloudless does not support saving an image without the full build so
+that there is some confidence that the image is in a predictable and
+reproducible state.
+
+## Files
+
+- `aws_blueprint.yml`: Blueprint for AWS.  Used to create the service with a
+  single instance.
+- `gce_blueprint.yml`: Blueprint for GCE.  Used to create the service with a
+  single instance.
+- `aws_image_build_configuration.yml`: Build configuration for AWS.  The only
+  difference is that it references a different blueprint.
+- `gce_image_build_configuration.yml`: Build configuration for GCE.  The only
+  difference is that it references a different blueprint.
+- `image_build_allow_ssh.sh`: Required startup script that sets up the build
+  user.  This is what allows SSH logins for the `configure` and `check` scripts.
+- `configure`: Shell script that is called by cloudless with the arguments
+  `<ssh_username>`, `<instance_public_ip>`, and `<ssh_private_key_path>` in that
+  order.  You can use this to configure an instance.
+- `check`: Shell script that is called by cloudless with the arguments
+  `<ssh_username>`, `<instance_public_ip>`, and `<ssh_private_key_path>` in that
+  order.  You can use this to check that an instance was configured as expected.

--- a/aws_blueprint.yml
+++ b/aws_blueprint.yml
@@ -1,0 +1,27 @@
+---
+network:
+  subnetwork_max_instance_count: 768
+
+placement:
+  availability_zones: 1
+
+instance:
+  public_ip: True
+  memory: 1GB
+  cpus: 1
+  gpu: false
+  disks:
+    - size: 8GB
+      type: standard
+      device_name: /dev/sda1
+
+image:
+  name: "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+
+initialization:
+  - path: "image_build_allow_ssh.sh"
+    vars:
+      cloudless_image_build_ssh_key:
+        required: false
+      cloudless_image_build_ssh_username:
+        required: false

--- a/aws_image_build_configuration.yml
+++ b/aws_image_build_configuration.yml
@@ -1,0 +1,28 @@
+---
+# Configuration script for the image builder commands.
+
+# Options for how to deploy the instance that we will configure and save into a
+# new image.  Currently, only the "blueprint" option is supported, which tells
+# the build command to create a service with only one instance using that
+# blueprint.  The default value is "blueprint.yml", but we have two different
+# blueprints for AWS and GCE because the base Ubuntu images that they provide
+# have different names.
+deploy:
+  blueprint: aws_blueprint.yml
+
+# Options for how to configure the instance.  The only currently supported
+# option is a "path" to a script.  Cloudless will call this script with the
+# arguments "<ssh_username> <instance_ip> <ssh_private_key_path>" in that order.
+configure:
+  path: configure
+
+# Options for how to check the instance.  The only currently supported option is
+# a "path" to a script.  Cloudless will call this script with the arguments
+# "<ssh_username> <instance_ip> <ssh_private_key_path>" in that order.
+check:
+  path: check
+
+# Options for how to save the instance.  Currently only the "name" option is
+# supported which is the name of the image that will be saved.
+save:
+  name: "cloudless-example-base-image-v0"

--- a/check
+++ b/check
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# An example check script.  This is run by the image build command on the
+# machine that the command is running on.  It will pass "<ssh_username>
+# <instance_ip> <ssh_private_key_path>" to this script in that order.  This
+# script has to handle sshing into the instance and running the checks.
+
+echo "Checking instance!"
+echo "ARGS: $*"
+echo "+ ssh -o StrictHostKeyChecking=no -i \"$3\" \"$1@$2\" uname -a"
+ssh -o StrictHostKeyChecking=no -i "$3" "$1@$2" uname -a
+
+echo "Configuring instance!"
+echo "ARGS: $*"
+
+# Run check here, perhaps by calling serverspec or server validation tool.

--- a/configure
+++ b/configure
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# An example configure script.  This is run by the image build command on the
+# machine that the command is running on.  It will pass "<ssh_username>
+# <instance_ip> <ssh_private_key_path>" to this script in that order.  This
+# script has to handle sshing into the instance and running the configuration.
+
+echo "Configuring instance!"
+echo "ARGS: $*"
+
+# Because configure runs right after deploy in the image build, this script has
+# to handle retrying ssh until it's available.  See
+# https://github.com/getcloudless/cloudless/issues/22 for a potential
+# improvement on this.
+TRIES=0
+while true; do
+    TRIES=$((TRIES + 1))
+    if [ $TRIES -gt 120 ]; then
+        echo "Exceeded maximum retries..."
+        exit 1
+    fi
+    echo "+ ssh -o StrictHostKeyChecking=no -i \"$3\" \"$1@$2\" uname -a"
+    ssh -o StrictHostKeyChecking=no -i "$3" "$1@$2" uname -a || (sleep 1;false)
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    echo "Retrying ssh.  Retry number $TRIES..."
+done
+
+# Run configuration here, perhaps by calling ansible or another configuration as
+# code tool.

--- a/gce_blueprint.yml
+++ b/gce_blueprint.yml
@@ -1,0 +1,27 @@
+---
+network:
+  subnetwork_max_instance_count: 768
+
+placement:
+  availability_zones: 1
+
+instance:
+  public_ip: True
+  memory: 1GB
+  cpus: 1
+  gpu: false
+  disks:
+    - size: 8GB
+      type: standard
+      device_name: /dev/sda1
+
+image:
+  name: "ubuntu-1604-xenial-v20180912"
+
+initialization:
+  - path: "image_build_allow_ssh.sh"
+    vars:
+      cloudless_image_build_ssh_key:
+        required: false
+      cloudless_image_build_ssh_username:
+        required: false

--- a/gce_image_build_configuration.yml
+++ b/gce_image_build_configuration.yml
@@ -1,0 +1,28 @@
+---
+# Configuration script for the image builder commands.
+
+# Options for how to deploy the instance that we will configure and save into a
+# new image.  Currently, only the "blueprint" option is supported, which tells
+# the build command to create a service with only one instance using that
+# blueprint.  The default value is "blueprint.yml", but we have two different
+# blueprints for AWS and GCE because the base Ubuntu images that they provide
+# have different names.
+deploy:
+  blueprint: gce_blueprint.yml
+
+# Options for how to configure the instance.  The only currently supported
+# option is a "path" to a script.  Cloudless will call this script with the
+# arguments "<ssh_username> <instance_ip> <ssh_private_key_path>" in that order.
+configure:
+  path: configure
+
+# Options for how to check the instance.  The only currently supported option is
+# a "path" to a script.  Cloudless will call this script with the arguments
+# "<ssh_username> <instance_ip> <ssh_private_key_path>" in that order.
+check:
+  path: check
+
+# Options for how to save the instance.  Currently only the "name" option is
+# supported which is the name of the image that will be saved.
+save:
+  name: "cloudless-example-base-image-v0"

--- a/image_build_allow_ssh.sh
+++ b/image_build_allow_ssh.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# This is a startup script that will be passed to both AWS and GCE instances.  The image build
+# framework runs the blueprint with the options "cloudless_image_build_ssh_key" and
+# "cloudless_image_build_ssh_username", so we have to have this script to properly install that
+# user.
+
+{% if cloudless_image_build_ssh_key %}
+adduser "{{ cloudless_image_build_ssh_username }}" --disabled-password --gecos "Cloudless Test User"
+echo "{{ cloudless_image_build_ssh_username }} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+mkdir /home/{{ cloudless_image_build_ssh_username }}/.ssh/
+echo "{{ cloudless_image_build_ssh_key }}" >> /home/{{ cloudless_image_build_ssh_username }}/.ssh/authorized_keys
+{% endif %}


### PR DESCRIPTION
This module shows an example of how to create a base image with cloudless.  See the README for details.